### PR TITLE
Add tf.tidy()

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,25 +119,29 @@
     }
 
     function getAccuracyScores(imageData) {
-      // convert to tensor (shape: [width, height, channels])
-      const channels = 1; // grayscale
-      let input = tf.fromPixels(imageData, channels);
+      
+      const score = tf.tidy(() => {
+        // convert to tensor (shape: [width, height, channels])  
+        const channels = 1; // grayscale              
+        let input = tf.fromPixels(imageData, channels);
 
-      // normalized
-      input = tf.cast(input, 'float32').div(tf.scalar(255));
+        // normalized
+        input = tf.cast(input, 'float32').div(tf.scalar(255));
 
-      // reshape input format (shape: [batch_size, width, height, channels])
-      input = input.expandDims();
+        // reshape input format (shape: [batch_size, width, height, channels])
+        input = input.expandDims();
 
-      // predict
-      const prediction = model.predict(input);
+        // predict
+        return model.predict(input).dataSync();
+      });
 
-      return prediction.dataSync();
+      return score;
     }
 
     function prediction() {
       const imageData = getImageData();
       const accuracyScores = getAccuracyScores(imageData);
+      console.log(tf.memory())
       const maxAccuracy = accuracyScores.indexOf(Math.max.apply(null, accuracyScores));
 
       const elements = document.querySelectorAll(".accuracy");

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
     }
 
     function getAccuracyScores(imageData) {
-      
+
       const score = tf.tidy(() => {
         // convert to tensor (shape: [width, height, channels])  
         const channels = 1; // grayscale              
@@ -141,7 +141,6 @@
     function prediction() {
       const imageData = getImageData();
       const accuracyScores = getAccuracyScores(imageData);
-      console.log(tf.memory())
       const maxAccuracy = accuracyScores.indexOf(Math.max.apply(null, accuracyScores));
 
       const elements = document.querySelectorAll(".accuracy");


### PR DESCRIPTION
#1 にて、`tf.tidy()`の存在を教えて頂いたので実装を追加。

## 概要

Tensorオブジェクトのメモリーリークを防ぐために、使用後にGPUメモリを開放する必要がある。
このメモリの開放は`tf.tidy()`で行うことができるのでこれを追加した。
https://js.tensorflow.org/api/0.10.0/#tidy

## 計測

tfjsによってどれだけメモリ確保が行われているかは`tf.memory()`にて計測ができる。
ので、0~9の数字について、連続でPredictionを行った際のメモリの状況を`tf.tidy()`の有り無しそれぞれで計測を行った。

### Before
```js
{unreliable: false, numTensors: 32, numDataBuffers: 22, numBytes: 9605380}
{unreliable: false, numTensors: 38, numDataBuffers: 26, numBytes: 9611696}
{unreliable: false, numTensors: 44, numDataBuffers: 30, numBytes: 9618012}
{unreliable: false, numTensors: 50, numDataBuffers: 34, numBytes: 9624328}
{unreliable: false, numTensors: 56, numDataBuffers: 38, numBytes: 9630644}
{unreliable: false, numTensors: 62, numDataBuffers: 42, numBytes: 9636960}
{unreliable: false, numTensors: 68, numDataBuffers: 46, numBytes: 9643276}
{unreliable: false, numTensors: 74, numDataBuffers: 50, numBytes: 9649592}
{unreliable: false, numTensors: 80, numDataBuffers: 54, numBytes: 9655908}
{unreliable: false, numTensors: 86, numDataBuffers: 58, numBytes: 9662224}
```

### After
```js
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
{unreliable: false, numTensors: 26, numDataBuffers: 18, numBytes: 9599064}
```

確かにメモリリークが起こらないよう、適切にメモリの開放が行われていることが確認できた。
